### PR TITLE
Fixes SA-CORE-2014-005

### DIFF
--- a/includes/database/database.inc
+++ b/includes/database/database.inc
@@ -717,7 +717,7 @@ abstract class DatabaseConnection extends PDO {
     // to expand it out into a comma-delimited set of placeholders.
     foreach (array_filter($args, 'is_array') as $key => $data) {
       $new_keys = array();
-      foreach ($data as $i => $value) {
+      foreach (array_values($data) as $i => $value) {
         // This assumes that there are no other placeholders that use the same
         // name.  For example, if the array placeholder is defined as :example
         // and there is already an :example_2 placeholder, this will generate


### PR DESCRIPTION
http://arstechnica.com/security/2014/10/drupal-sites-had-hours-to-patch-before-attacks-started/
https://www.drupal.org/SA-CORE-2014-005
https://www.drupal.org/node/2357241

Applied https://www.drupal.org/files/issues/SA-CORE-2014-005-D7.patch
